### PR TITLE
Add module exporting to the index file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,37 @@
+// Local Imports
+var
+    accordion = require( './lib/accordion' ),
+    actionSheet = require( './lib/action-sheet' ),
+    iconic = require( './lib/iconic' ),
+    interchange = require( './lib/interchange' ),
+    modal = require( './lib/modal' ),
+    notification = require( './lib/notification' ),
+    offcanvas = require( './lib/offcanvas' ),
+    panel = require( './lib/panel' ),
+    popup = require( './lib/popup' ),
+    tabs = require( './lib/tabs' ),
+    trigger = require( './lib/trigger' ),
+    animationUtil = require( './lib/utils/animation' ),
+    foundationAPI = require( './lib/utils/foundation-api' ),
+    mqHelpers = require( './lib/utils/mq-helpers' ),
+    mqInit = require( './lib/utils/mq-init' )
+
+module.exports = {
+    Accordion: accordion,
+    ActionSheet: actionSheet,
+    Iconic: iconic,
+    Interchange: interchange,
+    Modal: modal,
+    Notification: notification,
+    OffCanvas: offcanvas,
+    Panel: panel,
+    Popup: popup,
+    Tabs: tabs,
+    Trigger: trigger,
+    Utils: {
+        animation: animationUtil,
+        foundationAPI: foundationAPI,
+        mqHelpers: mqHelpers,
+        mqInit: mqInit
+    }
+}


### PR DESCRIPTION
This pull request aims to make the library more flexible internally by moving the require statements to a library level.

For example this would change this call:
```
Accordion = require('react-foundation-apps/lib/accordion')
```

into this call:
```
Accordion = require('react-foundation-apps').Accordion
```

We built this for ourselves so that we can conform with other library import statements and allow some flexibility in more structural changes to the guts of the library.

It is using our internal javascript code style which can look a bit weird, but I thought it would be worth contributing it back to the Open Source Library.