### PR TITLE
Accordion needs to use componentWillMount

### DIFF
--- a/lib/accordion/index.jsx
+++ b/lib/accordion/index.jsx
@@ -12,7 +12,7 @@ var Accordion = React.createClass({
       collapsible: false
     };
   },
-  componentDidMount: function () {
+  componentWillMount: function () {
     var sections = [];
     React.Children.forEach(this.props.children, function (child, index) {
       sections.push({active: false});


### PR DESCRIPTION
So that state.sections and 'active' are set for server side rendering.

componentDidMount is not called in the server side component lifecycle so its rendered differently from the client and the react checksum doesn't match.