### PR TITLE
classSet will be deprecated

### DIFF
--- a/src/tabs/tab.jsx
+++ b/src/tabs/tab.jsx
@@ -15,12 +15,8 @@ var Tab = React.createClass({
     this.props.selectTab(options);
   },
   render: function () {
-    var classes = {
-      'tab-item': true,
-      'is-active': this.props.active
-    };
     return (
-      <div className={cx(classes)} onClick={this.select}>
+      <div className={'tab-item ' + (this.props.active ? 'is-active' : '')} onClick={this.select}>
         {this.props.title}
       </div>
     );


### PR DESCRIPTION
CX has been moved to a separate repository and will deprecated in future versions of react.

ClassSet Repository: https://github.com/JedWatson/classnames
Reference: https://facebook.github.io/react/docs/class-name-manipulation.html